### PR TITLE
feat: 메인화면 데이터 분리(#14)

### DIFF
--- a/app/src/main/java/com/example/todo/airbnb/data/repository/MainRepositoryImpl.kt
+++ b/app/src/main/java/com/example/todo/airbnb/data/repository/MainRepositoryImpl.kt
@@ -1,0 +1,60 @@
+package com.example.todo.airbnb.data.repository
+
+import com.example.todo.airbnb.data.Accommodations
+import com.example.todo.airbnb.data.Travel
+import com.example.todo.airbnb.domain.repository.MainRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class MainRepositoryImpl: MainRepository {
+
+    private val locations = listOf(
+        "양재동, 서초구, 서울특별시",
+        "양재역 사거리, 양재1동",
+        "서울특별시 양재2동 시민의숲앞",
+        "서울특별시 양재2동 양재 IC",
+        "강릉시, 강원도",
+        "대전광역시 서구",
+        "대전광역시 중구",
+        "대전광역시 동구",
+        "경기도 수원시"
+    )
+
+    private val dummyImage =
+        "https://a0.muscache.com/im/pictures/2f13349d-879d-43c6-83e3-8e5679291d53.jpg?im_w=480"
+
+    private val travelList = listOf(
+        Travel(dummyImage, "서울", "차로 30분 거리"),
+        Travel(dummyImage, "광주", "차로 4시간 거리"),
+        Travel(dummyImage, "의정부", "차로 30분 거리"),
+        Travel(dummyImage, "수원", "차로 45분 거리"),
+        Travel(dummyImage, "대구", "차로 3.5시간 거리"),
+        Travel(dummyImage, "울산", "차로 4.5시간 거리"),
+        Travel(dummyImage, "대전", "차로 2시간 거리"),
+        Travel(dummyImage, "부천", "차로 30분 거리"),
+    )
+
+    private val accommodationList = listOf(
+        Accommodations(dummyImage, "자연생활을 만끽할 수\n있는 숙소"),
+        Accommodations(dummyImage, "독특한 공간"),
+        Accommodations(dummyImage, "자연생활을 만끽할 수\n있는 숙소"),
+        Accommodations(dummyImage, "독특한 공간"),
+        Accommodations(dummyImage, "자연생활을 만끽할 수\n있는 숙소"),
+        Accommodations(dummyImage, "독특한 공간"),
+        Accommodations(dummyImage, "자연생활을 만끽할 수\n있는 숙소"),
+        Accommodations(dummyImage, "독특한 공간")
+    )
+
+    override fun getSearchWordList(searchWord: String): Flow<List<String>> = flow {
+        val searchList = locations.filter { it.contains(searchWord) }
+        emit(searchList)
+    }
+
+    override fun getTravelLocations(): Flow<List<Travel>> = flow {
+        emit(travelList)
+    }
+
+    override fun getAccommodations(): Flow<List<Accommodations>> = flow {
+        emit(accommodationList)
+    }
+}

--- a/app/src/main/java/com/example/todo/airbnb/domain/repository/MainRepository.kt
+++ b/app/src/main/java/com/example/todo/airbnb/domain/repository/MainRepository.kt
@@ -1,0 +1,13 @@
+package com.example.todo.airbnb.domain.repository
+
+import com.example.todo.airbnb.data.Accommodations
+import com.example.todo.airbnb.data.Travel
+import kotlinx.coroutines.flow.Flow
+
+interface MainRepository {
+    fun getSearchWordList(searchWord: String): Flow<List<String>>
+
+    fun getTravelLocations(): Flow<List<Travel>>
+
+    fun getAccommodations(): Flow<List<Accommodations>>
+}

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/SearchViewModel.kt
@@ -4,13 +4,20 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.todo.airbnb.data.Accommodations
 import com.example.todo.airbnb.data.Travel
+import com.example.todo.airbnb.data.repository.MainRepositoryImpl
+import com.example.todo.airbnb.domain.repository.MainRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
-class SearchViewModel : ViewModel() {
+class SearchViewModel(
+    private val repository: MainRepository = MainRepositoryImpl(),
+) : ViewModel() {
 
     private val _searchWidgetState: MutableState<SearchWidgetState> =
         mutableStateOf(SearchWidgetState.CLOSED)
@@ -28,43 +35,6 @@ class SearchViewModel : ViewModel() {
     private val _accommodations = MutableStateFlow<List<Accommodations>>(emptyList())
     val accommodations: StateFlow<List<Accommodations>> = _accommodations.asStateFlow()
 
-    private val locations = listOf(
-        "양재동, 서초구, 서울특별시",
-        "양재역 사거리, 양재1동",
-        "서울특별시 양재2동 시민의숲앞",
-        "서울특별시 양재2동 양재 IC",
-        "강릉시, 강원도",
-        "대전광역시 서구",
-        "대전광역시 중구",
-        "대전광역시 동구",
-        "경기도 수원시"
-    )
-
-    private val dummyImage =
-        "https://a0.muscache.com/im/pictures/2f13349d-879d-43c6-83e3-8e5679291d53.jpg?im_w=480"
-
-    private val travelList = listOf(
-        Travel(dummyImage, "서울", "차로 30분 거리"),
-        Travel(dummyImage, "광주", "차로 4시간 거리"),
-        Travel(dummyImage, "의정부", "차로 30분 거리"),
-        Travel(dummyImage, "수원", "차로 45분 거리"),
-        Travel(dummyImage, "대구", "차로 3.5시간 거리"),
-        Travel(dummyImage, "울산", "차로 4.5시간 거리"),
-        Travel(dummyImage, "대전", "차로 2시간 거리"),
-        Travel(dummyImage, "부천", "차로 30분 거리"),
-    )
-
-    private val accommodationList = listOf(
-        Accommodations(dummyImage, "자연생활을 만끽할 수\n있는 숙소"),
-        Accommodations(dummyImage, "독특한 공간"),
-        Accommodations(dummyImage, "자연생활을 만끽할 수\n있는 숙소"),
-        Accommodations(dummyImage, "독특한 공간"),
-        Accommodations(dummyImage, "자연생활을 만끽할 수\n있는 숙소"),
-        Accommodations(dummyImage, "독특한 공간"),
-        Accommodations(dummyImage, "자연생활을 만끽할 수\n있는 숙소"),
-        Accommodations(dummyImage, "독특한 공간")
-    )
-
     init {
         getTravelLocations()
         getSearchWord("양재")
@@ -80,15 +50,28 @@ class SearchViewModel : ViewModel() {
     }
 
     private fun getSearchWord(searchWord: String) {
-        val searchList = locations.filter { it.contains(searchWord) }
-        _searchLocations.value = searchList
+        viewModelScope.launch {
+            repository.getSearchWordList(searchWord).collect {
+                _searchLocations.value = it
+            }
+        }
     }
 
     private fun getTravelLocations() {
-        _travelLocations.value = travelList.toList()
+        viewModelScope.launch {
+            val travelLocations = repository.getTravelLocations()
+            travelLocations.collect {
+                _travelLocations.value = it
+            }
+        }
     }
 
     private fun getAccommodations() {
-        _accommodations.value = accommodationList.toList()
+        viewModelScope.launch {
+            val accommodations = repository.getAccommodations()
+            accommodations.collect {
+                _accommodations.value = it
+            }
+        }
     }
 }


### PR DESCRIPTION
## Issue

- close #14 

## Description

- 메인화면 데이터 분리
  - viewModel에서 데이터 관리 → repository로 분리
  - 추후 비동기 통신을 위해 flow 적용

- 개선사항
  - viewModel의 repository 주입을 외부에서 주입할 수 있도록 의존성 주입하기